### PR TITLE
Use mariadb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Database dir
+/db
+
+# Config dir
+/.conf
+
 # Created by https://www.gitignore.io/api/django
  
 # vscodeの設定ファイルをgit管理対象から外す

--- a/digigru/settings.py
+++ b/digigru/settings.py
@@ -94,6 +94,14 @@ DATABASES = {
         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
     }
 }
+if not DEBUG:
+    DATABASES['default'] = {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': os.environ.get('MYSQL_DATABASE'),
+        'USER': os.environ.get('MYSQL_USER'),
+        'PASSWORD': os.environ.get('MYSQL_PASSWORD'),
+        'HOST': 'db'
+    }
 
 
 # Password validation

--- a/digigru/settings.py
+++ b/digigru/settings.py
@@ -23,7 +23,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = '7+r(a(j4v-79)duz!lx*93h7i2db)*6*9gz_@bqobqrbuz8g8!'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False if os.environ.get('DEBUG') == 'False' else True
 
 ALLOWED_HOSTS = ['app','localhost']
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       gunicorn -c gunicorn.py digigru.wsgi"
     environment:
       TZ: Asia/Tokyo
+    env_file:
+      - .conf/docker.env
     restart: always
   web:
     image: nginx:1.17
@@ -29,6 +31,13 @@ services:
     environment:
       TZ: Asia/Tokyo
     restart: always
+  db:
+    image: mariadb:10.4
+    volumes:
+      - ./db:/var/lib/mysql
+    env_file:
+      - .conf/docker.env
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
 
 volumes:
   staticfiles:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ libsass
 django-compressor
 django-sass-processor
 pillow
+mysqlclient == 1.4.6


### PR DESCRIPTION
use mariadb for production environment.

# 主要な変更点
- `.conf/docker.env`に設定をもたせることにしました。以下のような内容の設定ファイルが今後必要になります。
```
DEBUG=False
MYSQL_ROOT_PASSWORD=test
MYSQL_DATABASE=digigru
MYSQL_USER=digigru
MYSQL_PASSWORD=digigru
```

- DEBUG環境変数にFalseが入ってるか否かを考慮して自動でDEBUGをセットするようにしてあります。詳しくは差分をご確認ください。

- DEBUGがTrueの場合はmariadbではなくsqliteが利用されます。