### PR TITLE
Divide docker-compose.yml

### DIFF
--- a/digigru/settings.py
+++ b/digigru/settings.py
@@ -16,7 +16,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # SECRET_KEY = '' # 外部ファイルに設定
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False if os.environ.get('DEBUG') == 'False' else True
+DEBUG = False if str(os.environ.get('DEBUG')).lower() == 'false' else True
 
 ALLOWED_HOSTS = ['app','localhost']
 

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -26,12 +26,21 @@ services:
       - ./log/nginx:/var/log/nginx
       - staticfiles:/static:ro
       - ./media:/appmedia:ro
-    ports:
-      - 80:80
     depends_on:
       - app
     environment:
       TZ: Asia/Tokyo
+    restart: always
+  https-portal:
+    image: steveltn/https-portal:1
+    volumes:
+      - ./ssl_certs:/var/lib/https-portal
+    ports:
+      - 80:80
+      - 443:443
+    environment:
+      DOMAINS: "core.digicre.net -> http://web:80"
+      STAGE: "production"
     restart: always
   db:
     image: mariadb:10.4


### PR DESCRIPTION
docker-compose.ymlを開発用とプロダクション用に分割しました。
開発時はそのまま`docker-compose up`を、プロダクション環境では`docker-compose -f docker-compose.production.yml up`を実行します。