### PR TITLE
fix profile link in blog show

### DIFF
--- a/blog/templates/blog/show.htm
+++ b/blog/templates/blog/show.htm
@@ -23,7 +23,7 @@
             <div class="inline-block">
                 <div style="float: right;">
                     <img src="{{article.member.icon.url}}" alt="" style="height:50px; border-radius: 50%;">
-                    <a style="font-size:20px;margin-top:5px;" href="/member/{{article.member.id}}">{{article.member.username}}</a>
+                    <a style="font-size:20px;margin-top:5px;" href="/member/{{article.member.profile.id}}">{{article.member.username}}</a>
                 </div>
                 <div class="text-center">
                     <h1 style="border-bottom: solid 2px #87CEFA;">{{article.title}}</h1>


### PR DESCRIPTION
ブログの著者のプロフィールへ飛ぶリンクがuser.idになっていたのをprofile.idに修正