### PR TITLE
ブログのユーザーネーム表示を修正

### DIFF
--- a/blog/templates/blog/header.htm
+++ b/blog/templates/blog/header.htm
@@ -51,7 +51,7 @@
                         {% if user.icon.url != "/media/defo.png" %}
                         <img src="{{ user.icon.url }}" alt="User画像">
                         {% endif %}
-                        <p>{{ user.get_username }}</p>
+                        <p>{{ user.username }}</p>
                         <span class="caret"></span>
                     </a>
                     <div class="dropdown-menu" role="menu">


### PR DESCRIPTION
ブログの右上のプルダウンメニューにメールが表示されていたのを、ユーザー名が表示されるようにしました。