### PR TITLE
ページネーション処理を汎用化

### DIFF
--- a/bbs/templates/bbs/index.htm
+++ b/bbs/templates/bbs/index.htm
@@ -51,7 +51,7 @@
             <div class="col-md-10">
                 <h2>{{ channel_name }}</h2>
                 <p>{{ result_message }}</p>
-                {% for message in messages %}
+                {% for message in page_obj %}
                 <div class="card">
                     <div class="card-body">
                         <div class="card-title bbs-content-header">
@@ -105,34 +105,13 @@
                 </div>
                 {% endfor %}
 
-                {# ペジネーション #}
-                <nav aria-label="Page navigation">
-                    <ul class="pagination justify-content-center">
-                        {% if messages.has_previous %}
-                        <li class="page-item"><a class="page-link"
-                                href="/bbs/{{ channel_name }}/{{ messages.previous_page_number }}">&laquo;</a></li>
-                        {% else %}
-                        <li class="page-item disabled"><a class="page-link" href="#">&laquo;</a></li>
-                        {% endif %}
-
-                        {% for page in messages.paginator.page_range %}
-                        <li class="page-item {% if page == messages.number %} active {% endif %}"><a class="page-link"
-                                href="/bbs/{{ channel_name }}/{{ page }}">{{ page }}</a></li>
-                        {% endfor %}
-
-                        {% if messages.has_next %}
-                        <li class="page-item"><a class="page-link"
-                                href="/bbs/{{ channel_name }}/{{ messages.next_page_number }}">&raquo;</a></li>
-                        {% else %}
-                        <li class="page-item disabled"><a class="page-link" href="#">&raquo;</a></li>
-                        {% endif %}
-                    </ul>
-                </nav>
+                {# ページネーション #}
+                {% include 'includes/page.html' %}
 
             </div>
             <div class="bbs-main-flow-m">
                 <h2>{{ channel_name }}</h2>
-                {% for message in messages %}
+                {% for message in page_obj %}
                 <div class="bbs-content">
                     <div class="bbs-content-header">
                         <h4>{{ message.title }}</h4>
@@ -152,16 +131,8 @@
                 </div>
                 {% endfor %}
 
-                {# ペジネーションの部分（URLの書き方が微妙） #}
-                {% if messages.has_previous %}
-                <a href="/bbs/{{ channel_name }}">&laquo;first</a>
-                <a href="/bbs/{{ channel_name }}/{{ messages.previous_page_number }}">&laquo;prev</a>
-                {% endif %}
-                [{{ messages.number }}/{{ messages.paginator.num_pages }}]
-                {% if messages.has_next %}
-                <a href="/bbs/{{ channel_name }}/{{ messages.next_page_number }}">next&raquo;</a>
-                <a href="/bbs/{{ channel_name }}/{{ messages.paginator.num_pages }}">last&raquo;</a>
-                {% endif %}
+                {# ページネーション #}
+                {% include 'includes/page.html' %}
             </div>
         </div>
 

--- a/bbs/urls.py
+++ b/bbs/urls.py
@@ -6,7 +6,6 @@ urlpatterns = [
     path('', views.jump, name='bbs.jump'),
     path('<channel_name>/', views.index, name='bbs.index'),
     path('<channel_name>/show/<int:id>', views.show, name='bbs.show'),
-    path('<channel_name>/<int:page>', views.index, name='bbs.index'),
     path('create', views.create, name='bbs.create'),
     path('<channel_name>/show/<int:id>/edit', views.edit, name='bbs.edit'),
     path('message_stamp/<int:message_id>/<int:stamp_id>',views.message_stamp),

--- a/bbs/views.py
+++ b/bbs/views.py
@@ -15,9 +15,10 @@ def jump(request):
     return redirect(to='./' + ch_first.name)
 
 @login_required()
-def index(request, channel_name, page=1):
-    
+def index(request, channel_name):
     # GETアクセス時の処理
+    display_num = 5 # 1ページに表示するレコードの件数
+
     channel_list = get_user_channel(request)
     channel_now = Channel.objects.filter(name=channel_name).first()
 
@@ -29,11 +30,13 @@ def index(request, channel_name, page=1):
         messages = Message.objects.filter(channel=channel_now.id)
         result_message = 'すべてのスレッド（' + str(messages.count()) + '件）'
 
-    data = Paginator(messages, 5) # 1ページに5つスレッドを表示
+    data = Paginator(messages, display_num)
+    page = request.GET.get('page')
+
     params = {
         'channel_list': channel_list,
         'channel_name': channel_name,
-        'messages': data.get_page(page),
+        'page_obj': data.get_page(page),
         'stamps':Stamp.objects.all(),
         'result_message': result_message, 
     }

--- a/blog/templates/blog/index.htm
+++ b/blog/templates/blog/index.htm
@@ -8,7 +8,7 @@
     </div>
     <div class="row">
         <div class="col-md-12">
-            {% for article in articles %}
+            {% for article in page_obj %}
             <div class="card mt-2">
                 {% if article.article_image.url == 'null' %}
                 <img class="card-img-top" src="{{article.article_image.url}}" alt="カードの画像">
@@ -23,26 +23,8 @@
             </div>
             {% endfor %}
 
-            {# ペジネーション #}
-            <nav aria-label="Page navigation">
-                <ul class="pagination justify-content-center">
-                    {% if articles.has_previous %}
-                        <li class="page-item"><a class="page-link" href="/blog/{{ articles.previous_page_number }}">&laquo;</a></li>
-                    {% else %}
-                        <li class="page-item disabled"><a class="page-link" href="#">&laquo;</a></li>
-                    {% endif %}
-
-                    {% for page in articles.paginator.page_range %}
-                        <li class="page-item {% if page == articles.number %} active {% endif %}"><a class="page-link" href="/blog/{{ page }}">{{ page }}</a></li>
-                    {% endfor %}
-                    
-                    {% if articles.has_next %}
-                        <li class="page-item"><a class="page-link" href="/blog/{{ articles.next_page_number }}">&raquo;</a></li>
-                    {% else %}
-                        <li class="page-item disabled"><a class="page-link" href="#">&raquo;</a></li>
-                    {% endif %}
-                </ul>
-            </nav>
+            {# ページネーション #}
+            {% include 'includes/page.html' %}
         </div>
     </div>
     

--- a/blog/urls.py
+++ b/blog/urls.py
@@ -4,7 +4,6 @@ from . import views
 urlpatterns = [
     #path('', views.index, name='index'),
     path('', views.index, name='blog.index'),
-    path('<int:page>/', views.index, name='blog.index'),
     path('article/<int:id>', views.show, name='blog.show'),
     path('article/<int:id>/edit', views.edit, name='blog.edit'),
     path('article/create', views.create, name='blog.create'),

--- a/blog/views.py
+++ b/blog/views.py
@@ -13,13 +13,16 @@ from datetime import timedelta
 from .models import Article, ArticleTag, BlogEvent, EventArticle
 from .forms import *
 # Create your views here.
-def index(request,page=1):
-    articles_data = Paginator(Article.objects.filter(is_active=True),10)
+def index(request):
+    display_num = 30
+    page = request.GET.get('page')
+
+    articles_data = Paginator(Article.objects.filter(is_active=True), display_num)
     params = {
-        'articles':articles_data.get_page(page),
-        'is_login_user':request.user.is_authenticated,
+        'page_obj': articles_data.get_page(page),
+        'is_login_user': request.user.is_authenticated,
     }
-    return render(request,'blog/index.htm',params)
+    return render(request, 'blog/index.htm', params)
 
 def show(request,id=1):
     article = Article.objects.filter(id=id).first()

--- a/home/templates/includes/page.html
+++ b/home/templates/includes/page.html
@@ -1,0 +1,24 @@
+{% load url_replace %}
+
+<nav aria-label="Page navigation">
+    <ul class="pagination justify-content-center">
+        <!-- 前のページ -->
+        {% if page_obj.has_previous %}
+            <li class="page-item"><a class="page-link" href="?{% url_replace request 'page' page_obj.previous_page_number %}">&laquo;</a></li>
+        {% else %}
+            <li class="page-item disabled"><a class="page-link" href="#">&laquo;</a></li>
+        {% endif %}
+
+        <!-- ページ数 -->
+        {% for page in page_obj.paginator.page_range %}
+            <li class="page-item {% if page == page_obj.number %} active {% endif %}"><a class="page-link" href="?{% url_replace request 'page' page %}">{{ page }}</a></li>
+        {% endfor %}
+        
+        <!-- 次のページ -->
+        {% if page_obj.has_next %}
+            <li class="page-item"><a class="page-link" href="?{% url_replace request 'page' page_obj.next_page_number %}">&raquo;</a></li>
+        {% else %}
+            <li class="page-item disabled"><a class="page-link" href="#">&raquo;</a></li>
+        {% endif %}
+    </ul>
+</nav>

--- a/home/templatetags/url_replace.py
+++ b/home/templatetags/url_replace.py
@@ -1,0 +1,10 @@
+from django import template
+register = template.Library()
+
+@register.simple_tag
+def url_replace(request, field, value):
+    """GETパラメータの一部を置き換える"""
+
+    url_dict = request.GET.copy()
+    url_dict[field] = str(value)  # Django2.1の一部対策。通常はvalueだけでOK
+    return url_dict.urlencode()

--- a/issue/templates/issue/index.htm
+++ b/issue/templates/issue/index.htm
@@ -55,7 +55,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for issue in issues %}
+                        {% for issue in page_obj %}
                             <tr>
                                 <td>
                                     {% if perms.issue.change_issue %}
@@ -81,25 +81,7 @@
                 </table>
             </div>
             {# ペジネーション #}
-            <nav aria-label="Page navigation">
-                <ul class="pagination justify-content-center">
-                    {% if issues.has_previous %}
-                        <li class="page-item"><a class="page-link" href="/issue?={{ issues.previous_page_number }}">&laquo;</a></li>
-                    {% else %}
-                        <li class="page-item disabled"><a class="page-link" href="#">&laquo;</a></li>
-                    {% endif %}
-
-                    {% for page in issues.paginator.page_range %}
-                        <li class="page-item {% if page == issues.number %} active {% endif %}"><a class="page-link" href="/issue?={{ page }}">{{ page }}</a></li>
-                    {% endfor %}
-                    
-                    {% if issues.has_next %}
-                        <li class="page-item"><a class="page-link" href="/issue?={{ issues.next_page_number }}">&raquo;</a></li>
-                    {% else %}
-                        <li class="page-item disabled"><a class="page-link" href="#">&raquo;</a></li>
-                    {% endif %}
-                </ul>
-            </nav>
+            {% include 'includes/page.html' %}
         </div>
     </div>
 </div>

--- a/issue/views.py
+++ b/issue/views.py
@@ -7,7 +7,7 @@ from .models import Status, Issue
 from .forms import IssueForm, IssueEditForm
 
 @login_required()
-def index(request, page=1):
+def index(request):
     # GETアクセス時の処理
     display_num = 10 # 1ページに表示するレコードの件数
     
@@ -17,10 +17,11 @@ def index(request, page=1):
         issues = Issue.objects.all()
     
     issues_page = Paginator(issues, display_num)
+    page = request.GET.get('page')
 
     params = {
         'title': 'バグ報告・機能要望',
-        'issues': issues_page.get_page(page),
+        'page_obj': issues_page.get_page(page),
         'uncompleted_statuses': Status.objects.filter(is_completed=False),
         'records_num': issues.count(),
     }

--- a/member/templates/member/index.htm
+++ b/member/templates/member/index.htm
@@ -29,7 +29,7 @@
     <div class="row">
         <div class="col-md-12">
             <div class="card-columns">
-                {% for profile in profiles %}
+                {% for profile in page_obj %}
                 <div class="card" style="width: 18rem;">
                     <img class="card-img-top rounded-circle" src="{{profile.user.icon.url}}" alt="ユーザー画像">
                     <div class="card-body">
@@ -46,26 +46,8 @@
                 </div>
                 {% endfor %}
             </div>
-            {# ペジネーション #}
-            <nav aria-label="Page navigation">
-                <ul class="pagination justify-content-center">
-                    {% if profiles.has_previous %}
-                        <li class="page-item"><a class="page-link" href="/member?page={{ profiles.previous_page_number }}">&laquo;</a></li>
-                    {% else %}
-                        <li class="page-item disabled"><a class="page-link" href="#">&laquo;</a></li>
-                    {% endif %}
-
-                    {% for page in profiles.paginator.page_range %}
-                        <li class="page-item {% if page == profiles.number %} active {% endif %}"><a class="page-link" href="/member?page={{ page }}">{{ page }}</a></li>
-                    {% endfor %}
-                    
-                    {% if profiles.has_next %}
-                        <li class="page-item"><a class="page-link" href="/member?page={{ profiles.next_page_number }}">&raquo;</a></li>
-                    {% else %}
-                        <li class="page-item disabled"><a class="page-link" href="#">&raquo;</a></li>
-                    {% endif %}
-                </ul>
-            </nav>
+            {# ページネーション #}
+            {% include 'includes/page.html' %}
         </div>
     </div>
     

--- a/member/views.py
+++ b/member/views.py
@@ -11,17 +11,14 @@ from account.forms import UserEditForm
 def index(request):
     # GETアクセス時の処理
     display_num = 30
-    if 'page' in request.GET:
-        page = request.GET['page']
-    else:
-        page = 1
+    page = request.GET.get('page')
     
     profiles = Profile.objects.all()
     num = profiles.count()
     profiles_page = Paginator(profiles, display_num)
     params = {
         'num': num,
-        'profiles': profiles_page.get_page(page),
+        'page_obj': profiles_page.get_page(page),
     }
     return render(request, 'member/index.htm', params)
 

--- a/ringi/templates/ringi/index.htm
+++ b/ringi/templates/ringi/index.htm
@@ -56,7 +56,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for ringi in ringis %}
+                        {% for ringi in page_obj %}
                             <tr>
                                 <td>
                                     {% if perms.ringi.change_ringi %}
@@ -85,25 +85,7 @@
                 </table>
             </div>
             {# ペジネーション #}
-            <nav aria-label="Page navigation">
-                <ul class="pagination justify-content-center">
-                    {% if ringis.has_previous %}
-                        <li class="page-item"><a class="page-link" href="/ringi/{{ ringis.previous_page_number }}">&laquo;</a></li>
-                    {% else %}
-                        <li class="page-item disabled"><a class="page-link" href="#">&laquo;</a></li>
-                    {% endif %}
-
-                    {% for page in ringis.paginator.page_range %}
-                        <li class="page-item {% if page == ringis.number %} active {% endif %}"><a class="page-link" href="/ringi/{{ page }}">{{ page }}</a></li>
-                    {% endfor %}
-                    
-                    {% if ringis.has_next %}
-                        <li class="page-item"><a class="page-link" href="/ringi/{{ ringis.next_page_number }}">&raquo;</a></li>
-                    {% else %}
-                        <li class="page-item disabled"><a class="page-link" href="#">&raquo;</a></li>
-                    {% endif %}
-                </ul>
-            </nav>
+            {% include 'includes/page.html' %}
         </div>
     </div>
 </div>

--- a/ringi/urls.py
+++ b/ringi/urls.py
@@ -7,5 +7,4 @@ urlpatterns = [
     path('show/<int:id>', views.show, name='ringi.show'),
     path('edit/<int:id>', views.edit, name='ringi.edit'),
     path('delete/<int:id>', views.delete, name='ringi.delete'),
-    path('<int:page>', views.index, name='ringi.index'),
 ]

--- a/ringi/views.py
+++ b/ringi/views.py
@@ -7,7 +7,7 @@ from .models import Ringi, Status
 from .forms import RingiForm, RingiEditForm
 
 @login_required()
-def index(request, page=1):
+def index(request):
     # GETアクセス時の処理
     display_num = 10 # 1ページに表示するレコードの件数
     
@@ -17,10 +17,11 @@ def index(request, page=1):
         ringis = Ringi.objects.all()
     
     ringis_page = Paginator(ringis, display_num)
+    page = request.GET.get('page')
 
     params = {
         'title': '費用申請',
-        'ringis': ringis_page.get_page(page),
+        'page_obj': ringis_page.get_page(page),
         'uncompleted_statuses': Status.objects.filter(is_completed=False),
         'records_num': ringis.count(),
     }


### PR DESCRIPTION
ページネーション処理を汎用化しました。

今後新たに作る場合は、Pageオブジェクトをパラメータ`'page_obj'` としてtemplateに渡し、
ページネーション部品を挿入したい箇所に`{% include 'includes/page.html' %}` と書くようにしたいと思います。

参考: [Django、ページング処理まとめ - Narito Blog](https://blog.narito.ninja/detail/89/)