### PR TITLE
slackプレビュー用のmetaタグ追加

### DIFF
--- a/blog/templates/blog/header.htm
+++ b/blog/templates/blog/header.htm
@@ -3,9 +3,12 @@
 <html lang="ja">
 
 <head>
+    {# MetaTag #}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    {% block meta_tag %}{% endblock %}
+
     <link rel="icon" type="image/png" href="{% static "home/img/favicon.ico" %}">
 
     {# CSS #}

--- a/blog/templates/blog/show.htm
+++ b/blog/templates/blog/show.htm
@@ -2,6 +2,11 @@
 {% load markdown_extras %}
 {% load static %}
 {% block title %}{{article.title}}{% endblock %}
+{% block meta_tag %}
+<meta property="og:title" content="{{article.title}} | デジクリ" />
+<meta property="og:description" content="{{ article.content|markdown|striptags|truncatechars:100}}" />
+<meta property="og:image" content="{% static "home/img/favicon.ico" %}" />
+{% endblock %}
 {% block customCSS %}
 <style>
     #content{
@@ -51,7 +56,7 @@
             {% endfor %}
         </div>
     </div>
-    <div class="row">
+    <div class="row mb-5">
         <div class="col-12">
             <div id="content">{{ article.content|markdown|safe }}</div>
         </div>

--- a/blog/templates/blog/show.htm
+++ b/blog/templates/blog/show.htm
@@ -3,6 +3,8 @@
 {% load static %}
 {% block title %}{{article.title}}{% endblock %}
 {% block meta_tag %}
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:site" content="@sitdigicre" />
 <meta property="og:title" content="{{article.title}} | デジクリ" />
 <meta property="og:description" content="{{ article.content|markdown|striptags|truncatechars:100}}" />
 <meta property="og:image" content="{% static "home/img/favicon.ico" %}" />
@@ -15,7 +17,7 @@
     p, li{
         font-size: medium;
     }
-</style>
+</style>    
 {% endblock %}
 {% block content %}
 <div class="container">


### PR DESCRIPTION
## 変更点
- slackがプレビューを表示するようにmetaタグを追加
- descriptionは記事の内容の最初の100文字まで表示
- 画像はとりあえずicon
- twitterカード用の記述を追加

![image](https://user-images.githubusercontent.com/16465970/100687355-7c2e9900-33c3-11eb-93bd-5318a40f4a5b.png)
