### PR TITLE
ページタイトルを修正

### DIFF
--- a/blog/templates/blog/relay.htm
+++ b/blog/templates/blog/relay.htm
@@ -3,7 +3,7 @@
 {% load static %}
 {% load humanize %}
 {% load check %}
-{% block title %}ブログリレー2020summer{% endblock %}
+{% block title %}{{ event.name }}{% endblock %}
 {% block content %}
 <div class="container">
     {{ event.content | markdown | safe }}


### PR DESCRIPTION
- イベントページのタイトルが間違っていたので修正