### PR TITLE
CIのflake8におけるログ出力の修正

### DIFF
--- a/.github/actions/run-linters/entrypoint.sh
+++ b/.github/actions/run-linters/entrypoint.sh
@@ -13,6 +13,7 @@ GITHUB_TOKEN=$4
 GITHUB_PR_NUM=$5
 COMMENT=""
 SUCCESS=0
+LOG=""
 
 # if not set, assign default value
 if [ "$2" = "" ]; then
@@ -39,13 +40,19 @@ send_comment() {
 
 # run_autopep8 for static analysis
 run_autopep8() {
-    set +e
+    set +xe
 
     # including auto format
     OUTPUT=$(sh -c "autopep8 -r -i . $*" 2>&1)
     SUCCESS=$?
 
-    set -e
+    # for debug
+    # 調べたけどいい方法がなかったので, もっといい方法があったら修正してください
+    echo "$ autopep8 -r -i ."
+    echo "${OUTPUT}"
+
+
+    set -xe
 
     # exit successfully
     if [ ${SUCCESS} -eq 0 ]; then
@@ -78,17 +85,20 @@ run_flake8() {
 	# 拡張子が.pyのときのみflakeを動かす
 	if [ "${FILE##*.}" = "py" ]; then
 	    TMP=$(sh -c "flake8 ${FILE} $*" 2>&1)
-	    SUCCESS=$(($SUCCESS | $?))
+	    STATUS=$?
+
+	    # for debug
+	    # もっといい書き方があったら修正してください
+	    echo "flake ${FILE}"
+	    echo "${TMP}"
 
 	    # エラーログがある場合は連結
-	    if [ ${SUCCESS} -ne 0 ]; then
-		TMP2="$OUTPUT
+	    if [ ${STATUS} -ne 0 ]; then
+		OUTPUT="$OUTPUT
 $TMP"
-		OUTPUT="$TMP2"
 	    fi
-	    # ログ出力(for debug)
-	    echo "file: ${FILE} checked."
-	    echo "output: ${OUTPUT}"
+	    
+	    SUCCESS=$(($SUCCESS | $STATUS))
 	fi
     done
 

--- a/.github/actions/run-linters/entrypoint.sh
+++ b/.github/actions/run-linters/entrypoint.sh
@@ -13,7 +13,6 @@ GITHUB_TOKEN=$4
 GITHUB_PR_NUM=$5
 COMMENT=""
 SUCCESS=0
-LOG=""
 
 # if not set, assign default value
 if [ "$2" = "" ]; then
@@ -40,7 +39,7 @@ send_comment() {
 
 # run_autopep8 for static analysis
 run_autopep8() {
-    set +xe
+    set +e
 
     # including auto format
     OUTPUT=$(sh -c "autopep8 -r -i . $*" 2>&1)
@@ -52,7 +51,7 @@ run_autopep8() {
     echo "${OUTPUT}"
 
 
-    set -xe
+    set -e
 
     # exit successfully
     if [ ${SUCCESS} -eq 0 ]; then
@@ -114,7 +113,7 @@ $TMP"
 <details><summary>Show Detail</summary>
 
 \`\`\`
-$(echo "${OUTPUT}" | sed -e '$d')
+$(echo "${OUTPUT}")
 \`\`\`
 </details>
 
@@ -126,6 +125,7 @@ $(echo "${OUTPUT}" | sed -e '$d')
 # -------------
 # Main
 # ------------
+set +x
 case ${RUN} in
     "autopep8" )
 	run_autopep8
@@ -146,4 +146,5 @@ if [ ${SUCCESS} -ne 0 ]; then
     fi
 fi
 
+set -x
 exit ${SUCCESS}

--- a/.github/actions/run-linters/entrypoint.sh
+++ b/.github/actions/run-linters/entrypoint.sh
@@ -77,10 +77,15 @@ run_flake8() {
     for FILE in ${FILES}; do
 	# 拡張子が.pyのときのみflakeを動かす
 	if [ "${FILE##*.}" = "py" ]; then
-	    OUTPUT="$OUTPUT
-	    $(sh -c "flake8 ${FILE} $*" 2>&1)"
+	    TMP=$(sh -c "flake8 ${FILE} $*" 2>&1)
 	    SUCCESS=$(($SUCCESS | $?))
-	    # ログ出力
+
+	    # エラーログがある場合は連結
+	    if [ ${SUCCESS} -ne 0 ]; then
+		OUTPUT="$OUTPUT
+$TMP"
+	    fi
+	    # ログ出力(for debug)
 	    echo "file: ${FILE} checked."
 	    echo "output: ${OUTPUT}"
 	fi

--- a/.github/actions/run-linters/entrypoint.sh
+++ b/.github/actions/run-linters/entrypoint.sh
@@ -82,8 +82,9 @@ run_flake8() {
 
 	    # エラーログがある場合は連結
 	    if [ ${SUCCESS} -ne 0 ]; then
-		OUTPUT="$OUTPUT
+		TMP2="$OUTPUT
 $TMP"
+		OUTPUT="$TMP2"
 	    fi
 	    # ログ出力(for debug)
 	    echo "file: ${FILE} checked."

--- a/.github/actions/run-linters/entrypoint.sh
+++ b/.github/actions/run-linters/entrypoint.sh
@@ -77,11 +77,12 @@ run_flake8() {
     for FILE in ${FILES}; do
 	# 拡張子が.pyのときのみflakeを動かす
 	if [ "${FILE##*.}" = "py" ]; then
-	    OUTPUT+=$(sh -c "flake8 ${FILE} $*" 2>&1)
+	    OUTPUT="$OUTPUT
+	    $(sh -c "flake8 ${FILE} $*" 2>&1)"
 	    SUCCESS=$(($SUCCESS | $?))
 	    # ログ出力
-	    echo "${FILE} checked."
-	    echo "${OUTPUT}"
+	    echo "file: ${FILE} checked."
+	    echo "output: ${OUTPUT}"
 	fi
     done
 

--- a/.github/actions/run-linters/entrypoint.sh
+++ b/.github/actions/run-linters/entrypoint.sh
@@ -77,10 +77,11 @@ run_flake8() {
     for FILE in ${FILES}; do
 	# 拡張子が.pyのときのみflakeを動かす
 	if [ "${FILE##*.}" = "py" ]; then
-	    OUTPUT=$(sh -c "flake8 ${FILE} $*" 2>&1)
-	    echo -e "${FILE} checked."
-	    echo -e "${OUTPUT}"
+	    OUTPUT+=$(sh -c "flake8 ${FILE} $*" 2>&1)
 	    SUCCESS=$(($SUCCESS | $?))
+	    # ログ出力
+	    echo "${FILE} checked."
+	    echo "${OUTPUT}"
 	fi
     done
 

--- a/.github/actions/run-linters/entrypoint.sh
+++ b/.github/actions/run-linters/entrypoint.sh
@@ -78,6 +78,8 @@ run_flake8() {
 	# 拡張子が.pyのときのみflakeを動かす
 	if [ "${FILE##*.}" = "py" ]; then
 	    OUTPUT=$(sh -c "flake8 ${FILE} $*" 2>&1)
+	    echo -e "${FILE} checked."
+	    echo -e "${OUTPUT}"
 	    SUCCESS=$(($SUCCESS | $?))
 	fi
     done

--- a/.github/actions/run-linters/entrypoint.sh
+++ b/.github/actions/run-linters/entrypoint.sh
@@ -39,7 +39,7 @@ send_comment() {
 
 # run_autopep8 for static analysis
 run_autopep8() {
-    set +e
+    set +xe
 
     # including auto format
     OUTPUT=$(sh -c "autopep8 -r -i . $*" 2>&1)
@@ -51,7 +51,7 @@ run_autopep8() {
     echo "${OUTPUT}"
 
 
-    set -e
+    set -xe
 
     # exit successfully
     if [ ${SUCCESS} -eq 0 ]; then
@@ -74,7 +74,7 @@ $(echo "${OUTPUT}" | sed -e '$d')
 
 # run_flake8 for static analysis
 run_flake8() {
-    set +e
+    set +xe
 
     # https://github.community/t/git-ambiguous-argument-master/17832/2
     URL="https://api.github.com/repos/SIT-DigiCre/groupware/pulls/${GITHUB_PR_NUM}/files"
@@ -92,7 +92,7 @@ run_flake8() {
 	    echo "${TMP}"
 
 	    # エラーログがある場合は連結
-	    if [ ${STATUS} -ne 0 ]; then
+	    if [ -n "$TMP" ]; then
 		OUTPUT="$OUTPUT
 $TMP"
 	    fi
@@ -101,7 +101,7 @@ $TMP"
 	fi
     done
 
-    set -e
+    set -xe
 
     # exit successfully
     if [ ${SUCCESS} -eq 0 ]; then

--- a/blog/views.py
+++ b/blog/views.py
@@ -3,14 +3,14 @@ from django.http import HttpResponse
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
 from django.utils import timezone
+from django.http import *
 
 import datetime
 
 from .models import Article, ArticleTag, BlogEvent, EventArticle
 from .forms import NewArticleForm, EditArticleForm, NewArticleTagForm, EditArticleTagForm,EventArticleForm
 # Create your views here.
-def index(request):
-    print('hoge')
+def index(request)
     display_num = 30
     page = request.GET.get('page')
 

--- a/blog/views.py
+++ b/blog/views.py
@@ -10,6 +10,7 @@ from .models import Article, ArticleTag, BlogEvent, EventArticle
 from .forms import NewArticleForm, EditArticleForm, NewArticleTagForm, EditArticleTagForm,EventArticleForm
 # Create your views here.
 def index(request):
+    print('hoge')
     display_num = 30
     page = request.GET.get('page')
 

--- a/blog/views.py
+++ b/blog/views.py
@@ -3,14 +3,13 @@ from django.http import HttpResponse
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
 from django.utils import timezone
-from django.http import *
 
 import datetime
 
 from .models import Article, ArticleTag, BlogEvent, EventArticle
 from .forms import NewArticleForm, EditArticleForm, NewArticleTagForm, EditArticleTagForm,EventArticleForm
 # Create your views here.
-def index(request)
+def index(request):
     display_num = 30
     page = request.GET.get('page')
 


### PR DESCRIPTION
 - Flake8が正しく動いていないバグの確認と修正
   - 原因は文字列を追記せずに, 代入していたこと
   - [正しく出力できていることを確認](https://github.com/SIT-DigiCre/groupware/pull/83#issuecomment-738082105)
 - GitHub Actionsの実行結果に実行しているコマンドとその出力をロギング
   - `set +x`を利用
   - ref: [シェルスクリプトの一部分をデバッグするには](https://www.atmarkit.co.jp/flinux/rensai/linuxtips/787debugsspert.html)

Fixes #82 