### PR TITLE
絵文字がデータベースに入れられない問題を修正

### DIFF
--- a/digigru/settings.py
+++ b/digigru/settings.py
@@ -97,7 +97,10 @@ if not DEBUG:
         'NAME': os.environ.get('MYSQL_DATABASE'),
         'USER': os.environ.get('MYSQL_USER'),
         'PASSWORD': os.environ.get('MYSQL_PASSWORD'),
-        'HOST': 'db'
+        'HOST': 'db',
+        'OPTIONS': {
+            'charset': 'utf8mb4',
+        }
     }
 
 


### PR DESCRIPTION
調査したところ、Django側の設定でデータベースにアクセスする際の文字コードをutf8mb4にしてあげる必要があったようです。
手元の環境で確認したところ、問題は解消されました。
This resolves #91 
