### PR TITLE
dbコンテナが落ちたときに自動で再起動するように設定

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -49,6 +49,7 @@ services:
     env_file:
       - .conf/docker.env
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    restart: always
 
 volumes:
   staticfiles:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
     env_file:
       - .conf/docker.env
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    restart: always
 
 volumes:
   staticfiles:


### PR DESCRIPTION
`docker-compose.yml`, `docker-compose.production.yml`のdb欄に`restart: always`を追加