### PR TITLE
proxy_set_headerでHostに$http_hostをセット

### DIFF
--- a/backend/digigru/settings.py
+++ b/backend/digigru/settings.py
@@ -18,7 +18,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False if str(os.environ.get('DEBUG')).lower() == 'false' else True
 
-ALLOWED_HOSTS = ['app','localhost']
+ALLOWED_HOSTS = ['core.digicre.net', 'app', 'localhost']
 
 
 # Application definition

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -14,6 +14,7 @@ server {
 
     location / {
         proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header Host $http_host;
         proxy_pass http://app:8000;
     }
 


### PR DESCRIPTION
nginxからバックエンドにリクエストを渡す際に、Hostヘッダーをそのまま渡すように書き換えました。