### PR TITLE
Django側がhttpsを認識してくれない問題を修正

### DIFF
--- a/backend/digigru/settings.py
+++ b/backend/digigru/settings.py
@@ -97,6 +97,7 @@ CORS_ORIGIN_WHITELIST = [
     'https://blog.digicre.net',
 ]
 
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # Database
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -15,6 +15,7 @@ server {
     location / {
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
         proxy_pass http://app:8000;
     }
 


### PR DESCRIPTION
X-Forwarded-Protoをnginx側でセットして、Django側でチェックするように変更。